### PR TITLE
Calculate total points from post list

### DIFF
--- a/src/Pages/Profile.jsx
+++ b/src/Pages/Profile.jsx
@@ -37,6 +37,7 @@ export default function Profile() {
                 {(value) => {
                     let [ user, posts ] = value
                     user = user.user
+                    const totalPoints = user.total_points > 0 ? user.total_points : posts.reduce((n, p) => n + p.points, 0);
                     return(
                         <Box className='flex flex-col items-center'>
                             <Box className='flex flex-row justify-around items-center' width={480}>
@@ -45,7 +46,7 @@ export default function Profile() {
                                 </Box>
                                 <Box>
                                     <h2 className="text-2xl font-bold mb-2">{user.player_name}</h2>
-                                    <p>Total Points: {user.total_points}</p>
+                                    <p>Total Points: {totalPoints}</p>
                                     <p>Posts: {posts.length}</p>
                                 </Box>
                             </Box>


### PR DESCRIPTION
The user data API always seems to return 0 points so this change displays a more accurate point count by adding up the points from all of the user's posts.