### PR TITLE
Feature: Home nav item, highlighting and tooltip

### DIFF
--- a/src/Components/Header.jsx
+++ b/src/Components/Header.jsx
@@ -1,7 +1,7 @@
 import { Box, Container } from "@mui/material"
-import { NavLink } from "react-router-dom";
 import { AccountBoxOutlined, PostAdd, LeaderboardOutlined } from '@mui/icons-material';
 import { useNavigate } from "react-router-dom";
+import NavIcon from "./NavIcon";
 
 export default function Header() {
 
@@ -14,15 +14,21 @@ export default function Header() {
                 <p className="text-md text-slate-300">An <span className='text-sky-400 italic'>unofficial</span> alternate front end for Pithee</p>
             </Box>
             <Box className='flex flex-row justify-between m-auto mb-6' width={125}>
-                <Box>
-                    <NavLink to='/me'><AccountBoxOutlined /></NavLink>
-                </Box>
-                <Box>
-                    <NavLink to='/leaderboard'><LeaderboardOutlined /></NavLink>
-                </Box>
-                <Box>
-                    <NavLink to='/post'><PostAdd /></NavLink>
-                </Box>
+                <NavIcon
+                    label="Profile"
+                    href="/me"
+                    icon={AccountBoxOutlined}
+                />
+                <NavIcon
+                    label="Leaderboard"
+                    href="/leaderboard"
+                    icon={LeaderboardOutlined}
+                />
+                <NavIcon
+                    label="Add Post"
+                    href="/post"
+                    icon={PostAdd}
+                />
             </Box>
         </Container>
     )

--- a/src/Components/Header.jsx
+++ b/src/Components/Header.jsx
@@ -1,5 +1,5 @@
 import { Box, Container } from "@mui/material"
-import { AccountBoxOutlined, PostAdd, LeaderboardOutlined } from '@mui/icons-material';
+import { AccountBoxOutlined, PostAdd, LeaderboardOutlined, WindowOutlined } from '@mui/icons-material';
 import { useNavigate } from "react-router-dom";
 import NavIcon from "./NavIcon";
 
@@ -14,6 +14,11 @@ export default function Header() {
                 <p className="text-md text-slate-300">An <span className='text-sky-400 italic'>unofficial</span> alternate front end for Pithee</p>
             </Box>
             <Box className='flex flex-row justify-between m-auto mb-6' width={125}>
+                <NavIcon
+                    label="Vote"
+                    href="/"
+                    icon={WindowOutlined}
+                />
                 <NavIcon
                     label="Profile"
                     href="/me"

--- a/src/Components/NavIcon.jsx
+++ b/src/Components/NavIcon.jsx
@@ -1,0 +1,17 @@
+import { Box, Tooltip } from "@mui/material"
+import { NavLink, useLocation } from "react-router-dom";
+
+export default function NavIcon({ label, href, icon }) {
+    const location = useLocation()
+    const IconComponent = icon
+    const isActive = location.pathname === href
+    return (
+        <Tooltip title={label}>
+            <Box>
+                <NavLink to={href}>
+                    <IconComponent color={isActive ? "primary" : undefined} />
+                </NavLink>
+            </Box>
+        </Tooltip>
+    )
+}


### PR DESCRIPTION
- Adds nav item for home page as it is unclear how to get back to the home page from other pages
- Add blue highlight to icon for currently selected page
- Add tooltip which appears on hover explaining what each page is

Nav labels:
- Vote
- Profile
- Leaderboard
- Add Post

**Screenshots**
Highlighted icon of home page
<img width="556" alt="Screenshot 2024-04-04 at 1 42 03 PM" src="https://github.com/gabehf/Prittee/assets/4233623/5567505a-8027-45c4-a236-1e48516e8b36">
Tooltip showing page name on hover
<img width="547" alt="Screenshot 2024-04-04 at 1 42 12 PM" src="https://github.com/gabehf/Prittee/assets/4233623/9469f064-624d-4cb4-badb-9b1862439de0">
